### PR TITLE
fix: use full country name on profile page

### DIFF
--- a/src/spa/view/pages/profilePage/profilePageView.ts
+++ b/src/spa/view/pages/profilePage/profilePageView.ts
@@ -9,6 +9,7 @@ import * as constants from '@src/spa/view/pages/profilePage/constants';
 import { IProfilePage } from '@src/spa/view/pages/profilePage/types';
 import { IProfilePageLogic } from '@src/spa/logic/profile/profilePageLogic/types';
 import ProfilePageLogic from '@src/spa/logic/profile/profilePageLogic/profilePageLogic';
+import { country } from '@src/spa/view/select/country';
 
 export default class ProfilePageView extends View implements IProfilePage {
   private readonly firstName: IElementCreator;
@@ -193,7 +194,7 @@ export default class ProfilePageView extends View implements IProfilePage {
 
   private createAddressField(address: CustomAddress): IElementCreator {
     const container = new ElementCreator(constants.addressContainerParams);
-    const country = this.createInfoTextParagraph();
+    const countryName = this.createInfoTextParagraph();
     const city = this.createInfoTextParagraph();
     const street = this.createInfoTextParagraph();
     const postalCode = this.createInfoTextParagraph();
@@ -223,12 +224,12 @@ export default class ProfilePageView extends View implements IProfilePage {
       container.addInnerElement(billing);
     }
 
-    country.setTextContent(`Country: ${address.country}`);
+    if (address.country in country) countryName.setTextContent(`Country: ${country[address.country]}`);
+    else countryName.setTextContent('Country: undefined');
     city.setTextContent(`City: ${address.city}`);
     street.setTextContent(`Street: ${address.street}`);
     postalCode.setTextContent(`Postal code: ${address.postcode}`);
-    container.addInnerElement(country, city, street, postalCode);
-
+    container.addInnerElement(countryName, city, street, postalCode);
     return container;
   }
 

--- a/src/spa/view/select/country.ts
+++ b/src/spa/view/select/country.ts
@@ -1,4 +1,4 @@
-export const country = {
+export const country: Record<string, string> = {
   title: 'Select country',
   AM: 'Armenia',
   AZ: 'Azerbaijan',


### PR DESCRIPTION
#### Pull Request Naming

use full country name on profile page

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

---

#### Description

1. Sprint: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%231.md)
2. Task or feature description link (if it is): [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint1/RSS-ECOMM-1_21.md)
3. Done: 03.08.2023 17.40
4. Description: 
  - use full country name on profile page